### PR TITLE
Change IP and port to be configurable

### DIFF
--- a/server_tests/test/clientTests.js
+++ b/server_tests/test/clientTests.js
@@ -13,7 +13,7 @@ var Q = require('../node_modules/q');
 var Util = require('../lib/util');
 
 describe("RUST API TEST SUITE", function() {
-    var testClient = new OscClient();
+    var testClient = new OscClient(process.env.SCARLET_TEST_HOST, process.env.SCARLET_TEST_PORT);
     var Comparison = new Compare();
     var Utility = new Util(testClient);
     var defaultOptionsFile = './defaults/mock.json';


### PR DESCRIPTION
Added environmental variables when creating an OscClient. This is so ports and IP can be configurable depending on the camera.

    $ SCARLET_TEST_HOST=192.168.0.100 SCARLET_TEST_PORT=80 $(npm bin)/mocha 
